### PR TITLE
Fix bug when daemon skips adding replica path on START command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -127,11 +127,10 @@ fn main() -> Fallible<()> {
 
                         if let Some(dir) = args.get(2) {
                             replica_path = replica_path.join(dir);
-                        } else {
-                            watcher.watch(&replica_path, RecursiveMode::Recursive)?;
-                            replicas.insert(replica_id, replica_path.clone());
-                            debug!("replicas: {:?}", replicas);
                         }
+                        watcher.watch(&replica_path, RecursiveMode::Recursive)?;
+                        replicas.insert(replica_id, replica_path.clone());
+                        debug!("replicas: {:?}", replicas);
                         send_ack();
                     }
                     "DIR" => {


### PR DESCRIPTION
This happens when START command is of the format:

  START replica-id /root/of/path relative/subpath

which unison sends when Path= arguments are present in the
configuration.

I think this also fixes https://github.com/autozimu/unison-fsmonitor/issues/1

Thanks!