### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ dev-version = false
 percent-encoding = "2"
 failure = { version = "0", default-features = false, features = ["std"] }
 notify = "4"
-log = "0"
-env_logger = "0"
+log = "0.4"
+env_logger = "0.9"
 
 [profile.dev]
 split-debuginfo = "unpacked"


### PR DESCRIPTION
Mentioning "0" would mean cargo would pick the latest dependency which is versioned "0.*" which would include versions incompatible with the one that this crate was written with and may break your create.