### PR TITLE
It is better to use the repository field in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "unison-fsmonitor"
 description = "unison-fsmonitor implementation"
-homepage = "https://github.com/autozimu/unison-fsmonitor"
+repository = "https://github.com/autozimu/unison-fsmonitor"
 version = "0.3.4"
 authors = ["Junfeng Li <autozimu@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.