### PR TITLE
Exit on error

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -299,6 +299,7 @@ impl<WATCH: Watch, WRITE: Write> Monitor<WATCH, WRITE> {
 
     fn send_error(&mut self, msg: &str) {
         self.send_cmd("ERROR", &[msg]);
+        std::process::exit(1);
     }
 }
 


### PR DESCRIPTION
If the main Unison process exits, e.g. when the SSH connection is dropped, fsmonitor keeps printing errors in an infinite loop. This, in turn, uses tons of CPU and memory, to the point of exhausting system resources. Exiting whenever it detects an error prevents this issue.

Closes #27. This is an implementation of the fix suggested in the same issue.